### PR TITLE
[HotFix] Resolve bugs in latest version 4.3.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ const AudioDefaultConfig = Object.freeze({
   Channels: 2,
   AudioQuality: AudioQualityIOS.HIGH ?? 'High',
   AudioEncoding: Platform.OS === 'ios' ? AudioEncodingIOS.AAC : AudioEncodingAndroid.AAC,
-  OutputFormat: AudioOuputFormatAndroid.AAC_ADTS ?? 'acc_adts',
+  OutputFormat: AudioOuputFormatAndroid.AAC_ADTS ?? 'aac_adts',
   MeteringEnabled: false,
   ProgressUpdateInterval: 1000,
   MeasurementMode: false,


### PR DESCRIPTION
- Fix record duration is always equal to zero. This issue happens since the duration was reset when the record stops and before sending success event.
- Fix crash due to null audio recorder instance if the recorder failed to initialized. Issue happens due using the recorder instance before checking initialization error